### PR TITLE
Issue #18: Incorrect parsing of varchar arrays

### DIFF
--- a/src/main/java/com/github/pgasync/impl/conversion/ArrayConversions.java
+++ b/src/main/java/com/github/pgasync/impl/conversion/ArrayConversions.java
@@ -94,7 +94,9 @@ enum ArrayConversions  {
                 i = readString(text, i, values);
             } else if(c == '{') {
                 i = readArray(text, i, values);
-            } else if (c == 'N') {
+            } else if (c == 'N' && text.length > i + 4 &&
+                    text[i+1] == 'U' && text[i+2] == 'L' && text[i+3] == 'L' &&
+                    (text[i+4] == ',' || text[i+4] == '}' || Character.isWhitespace(text[i+4]))) {
                 i = readNull(i, values);
             } else {
                 i = readValue(text, i, values);

--- a/src/test/java/com/github/pgasync/impl/ArrayConversionsTest.java
+++ b/src/test/java/com/github/pgasync/impl/ArrayConversionsTest.java
@@ -6,6 +6,7 @@ import org.junit.*;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -192,5 +193,21 @@ public class ArrayConversionsTest {
         for(int i = 0; i < input.length; i++) {
             assertEquals(input[i], output[i].longValue());
         }
+    }
+
+    @Test
+    public void shouldParseUnquotedStringsCorrectly() {
+        String[] values = new String[] {"NotNull", "NULLA", "string", null};
+        dbr.query("INSERT INTO CA_TEST (TEXTA) VALUES($1)", Collections.singletonList(values));
+        Row row = dbr.query("SELECT * FROM CA_TEST").row(0);
+        assertArrayEquals(values, row.getArray("TEXTA", String[].class));
+    }
+
+    @Test
+    public void shouldParseNullTextCorrectly() {
+        String[] values = new String[] {"NULL", null, "string"};
+        dbr.query("INSERT INTO CA_TEST (TEXTA) VALUES($1)", Collections.singletonList(values));
+        Row row = dbr.query("SELECT * FROM CA_TEST").row(0);
+        assertArrayEquals(values, row.getArray("TEXTA", String[].class));
     }
 }


### PR DESCRIPTION
This fixes #18, parsing of arrays from Postgres containing unquoted strings. These were previously incorrectly parsed as NULL if a string started with an uppercase N.