### PR TITLE
Fix NullPointerException in array conversion

### DIFF
--- a/src/main/java/com/github/pgasync/impl/conversion/ArrayConversions.java
+++ b/src/main/java/com/github/pgasync/impl/conversion/ArrayConversions.java
@@ -60,6 +60,10 @@ enum ArrayConversions  {
             throw new IllegalArgumentException("Primitive arrays are not supported due to possible NULL values");
         }
 
+        if (value == null) {
+            return null;
+        }
+
         char[] text = new String(value, UTF_8).toCharArray();
         List<List<Object>> holder = new ArrayList<>(1);
 

--- a/src/test/java/com/github/pgasync/impl/ArrayConversionsTest.java
+++ b/src/test/java/com/github/pgasync/impl/ArrayConversionsTest.java
@@ -128,6 +128,13 @@ public class ArrayConversionsTest {
     }
 
     @Test
+    public void selectNull() {
+        dbr.query("INSERT INTO CA_TEST (TEXTA) VALUES (NULL);");
+
+        assertArrayEquals(null, getRow().getArray("TEXTA", String[].class));
+    }
+
+    @Test
     public void roundtripInt() {
         Integer[][] a = new Integer[][]{
             new Integer[]{1, 2, 3},


### PR DESCRIPTION
`Row#getArray()` on a column where the value is `NULL` would result in an `NullPointerException`. I have changed this so it instead returns `null`. An alternative could be to have a method to check if a column is null.